### PR TITLE
Add round timer functionality

### DIFF
--- a/src/components/RoundTimer.test.ts
+++ b/src/components/RoundTimer.test.ts
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils'
+import RoundTimer from './RoundTimer.vue'
+import { describe, expect, it} from 'vitest'
+import { Game, GameState, GameSettings, RoundTimerSettings, RoundState, PlayerState } from '../utils/model'
+
+describe('RoundTimer', () => {
+    it('renders the round timer correctly', () => {
+        const gameSettings = new GameSettings(new RoundTimerSettings())
+        const game = new Game('Software', 1, 'ABC', gameSettings)
+        const gameState = new GameState(game, new Map<String, PlayerState>(), 'https://some-url.com', RoundState.INIT, undefined)
+        const wrapper = mount(RoundTimer, { props: { gameState } })
+        const progressBarElem = wrapper.get('div#round-timer-progress-bar')
+
+        expect(progressBarElem.text()).toBe('05:00')
+        expect(progressBarElem.classes()).toContain('bg-success')
+    })
+})

--- a/src/components/RoundTimer.vue
+++ b/src/components/RoundTimer.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { GameState } from '../utils/model'
+
+const props = defineProps({
+    gameState: { type: GameState, required: true },
+})
+
+const elapsedMS = ref(0)  // elapsed time in milliseconds
+const timer = ref(0)  // handle to the timer callback
+
+// convert from minutes to milliseconds
+const maximum = props.gameState.game.game_settings.round_timer_settings !== undefined ? props.gameState.game.game_settings.round_timer_settings.maximum * 60 * 1000 : 0
+const warning = props.gameState.game.game_settings.round_timer_settings !== undefined ? props.gameState.game.game_settings.round_timer_settings.warning * 60 * 1000 : 0
+
+const progress = computed<number>(() => {
+    if(props.gameState.game.game_settings.round_timer_settings === undefined) {
+        return 0
+    }
+
+    if(elapsedMS.value >= maximum) {
+        clearInterval(timer.value)  // stop the timer
+        return 100
+    }
+
+    return elapsedMS.value / maximum * 100
+})
+
+const progressClass = computed<string>(() => {
+    if(props.gameState.game.game_settings.round_timer_settings === undefined) {
+        return 'progress-bar'
+    }
+
+    if(elapsedMS.value < warning) {
+        return 'progress-bar bg-success'
+    } else if(elapsedMS.value < maximum) {
+        return 'progress-bar bg-warning'
+    } else {
+        return 'progress-bar bg-danger'
+    }
+})
+
+const countdownValue = computed<string>(() => {
+    if(props.gameState.game.game_settings.round_timer_settings === undefined) {
+        return ''
+    }
+
+    const remaining = maximum - elapsedMS.value
+    if(remaining <= 0) {
+        return '00:00'
+    }
+    const minutes = Math.floor(remaining / 1000 / 60)
+    const seconds = Math.floor((remaining - minutes * 1000 * 60) / 1000)
+    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+})
+
+onMounted(() => {
+    if(props.gameState.game.game_settings.round_timer_settings !== undefined) {
+        if(props.gameState.round_start !== undefined) {
+            elapsedMS.value = Date.now() - Date.parse(props.gameState.round_start)
+        }
+
+        // start the timer
+        timer.value = setInterval(() => {
+            elapsedMS.value += 1000
+        }, 1000)
+    }
+})
+
+</script>
+
+<template>
+    <div class="round-timer">
+        <div class="progress">
+            <div id="round-timer-progress-bar" :class="progressClass" role="progressbar" :style="{ width: progress + '%'}" :aria-valuenow="progress" aria-valuemin="0" aria-valuemax="100">{{ countdownValue }}</div>
+        </div>
+    </div>
+</template>
+  
+<style scoped>
+.round-timer {
+    margin: 0.5rem 0;
+}
+</style>

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { describe, expect, it, afterEach } from 'vitest';
 import { buildUrl, fetchDecks, fetchDeck, createGame, joinGame } from './api';
-import { Deck, Player } from './model';
+import { Deck, Player, RoundTimerSettings } from './model';
 
 const mock = new MockAdapter(axios);
 
@@ -41,7 +41,7 @@ describe('API utility functions', () => {
     mock.onPost('http://127.0.0.1:8000/api/game').reply(200, { code: gameCode });
     mock.onPost(`http://127.0.0.1:8000/api/join/${gameCode}`).reply(200, player);
 
-    const result = await createGame(gameName, deckId, player);
+    const result = await createGame(gameName, deckId, player, new RoundTimerSettings());
     expect(result).toEqual(gameCode);
   });
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Deck, Player } from './model';
+import { Deck, Player, GameSettings, RoundTimerSettings } from './model';
 
 // allow host and port to be overridden by an env variable
 const hostAndPort = import.meta.env.VITE_API_HOST || '127.0.0.1:8000'
@@ -37,11 +37,12 @@ async function fetchDeck(id: number): Promise<Deck> {
  * @param gameName - the name of the game
  * @param deckId - the selected deck for this game
  * @param player - the player creating the game
+ * @param roundTimerSettings - the round timer settings for this game
  * @returns {string} - the unique code for this game
  */
-async function createGame(gameName: string, deckId: number, player: Player): Promise<string> {
+async function createGame(gameName: string, deckId: number, player: Player, roundTimerSettings: RoundTimerSettings | undefined): Promise<string> {
   // create the game
-  const resp = await axios.post(buildUrl('game'), { name: gameName, deck_id: deckId})
+  const resp = await axios.post(buildUrl('game'), { name: gameName, deck_id: deckId, game_settings: new GameSettings(roundTimerSettings)})
   const code: string = resp.data.code
 
   // and join the newly created game - the person that creates the game is automatically set to the game admin

--- a/src/utils/model.test.ts
+++ b/src/utils/model.test.ts
@@ -1,4 +1,4 @@
-import { Card, Deck, Player, Game, PlayerState, GameState, MessageType, GenericMessage, RoundState } from './model';
+import { Card, Deck, Player, Game, PlayerState, GameState, GenericMessage, GameSettings } from './model';
 import { describe, expect, it } from 'vitest';
 
 describe('model.ts', () => {
@@ -36,7 +36,7 @@ describe('model.ts', () => {
 
     describe('Game', () => {
         it('should create a new Game instance', () => {
-            const game = new Game('Poker', 1, 'ABC');
+            const game = new Game('Poker', 1, 'ABC', new GameSettings());
             expect(game.name).toBe('Poker');
             expect(game.deck_id).toBe(1);
             expect(game.code).toBe('ABC');
@@ -57,15 +57,16 @@ describe('model.ts', () => {
 
     describe('GameState', () => {
         it('should create a new GameState instance', () => {
-            const game = new Game('Poker', 1, 'ABC');
+            const game = new Game('Poker', 1, 'ABC', new GameSettings());
             const playerStates = new Map<string, PlayerState>();
             const ticketUrl = 'https://example.com';
             const roundState = 'INIT';
-            const gameState = new GameState(game, playerStates, ticketUrl, roundState);
+            const gameState = new GameState(game, playerStates, ticketUrl, roundState, undefined);
             expect(gameState.game).toBe(game);
             expect(gameState.player_states).toBe(playerStates);
             expect(gameState.ticket_url).toBe(ticketUrl);
             expect(gameState.round_state).toBe(roundState);
+            expect(gameState.game.game_settings.round_timer_settings).toBe(undefined);
         });
     });
 

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -22,11 +22,28 @@ class Player {
   }
 }
 
+
+class RoundTimerSettings {
+  constructor(public maximum: number = 5, public warning: number = 4) {
+    this.maximum = maximum
+    this.warning = warning
+  }
+}
+
+
+class GameSettings {
+  constructor(public round_timer_settings: RoundTimerSettings | undefined = undefined) {
+    this.round_timer_settings = round_timer_settings
+  }
+}
+
+
 class Game {
-  constructor(public name: string, public deck_id: number, public code: string) {
+  constructor(public name: string, public deck_id: number, public code: string, public game_settings: GameSettings) {
     this.name = name
     this.deck_id = deck_id
     this.code = code
+    this.game_settings = game_settings
   }
 }
 
@@ -51,11 +68,12 @@ type RoundStateStrings = keyof typeof RoundState
 
 class GameState {
   constructor(public game: Game, public player_states: Map<String, PlayerState>, public ticket_url: string,
-              public round_state: RoundStateStrings) {
+              public round_state: RoundStateStrings, public round_start: string | undefined) {
     this.game = game
     this.player_states = player_states
     this.ticket_url = ticket_url
     this.round_state = round_state
+    this.round_start = round_start  // only required if a user joins mid round
   }
 }
 
@@ -90,4 +108,4 @@ class GenericMessage<Payload> {
   }
 }
 
-export { Card, Deck, Player, Game, PlayerState, GameState, MessageType, GenericMessage, RoundState }
+export { Card, Deck, Player, Game, PlayerState, GameState, MessageType, GenericMessage, RoundState, RoundTimerSettings, GameSettings }


### PR DESCRIPTION
This pull request adds round timer functionality to the game. The admin can now start a new round with options for a timer that starts at 0 and counts up to a maximum round time, and a warning threshold time that change the timer's color at certain thresholds. This addresses issue #6.